### PR TITLE
Make suggestion when "uncertain" but a match is still found

### DIFF
--- a/src/commands/move_command.rs
+++ b/src/commands/move_command.rs
@@ -73,8 +73,8 @@ impl MoveCommand<'_> {
             Ok(move_) => Ok(move_),
             Err(_) => {
                 let output = matcher::build_unknown_name(
-                    &successful_match.suggested_name,
                     &successful_match.keyword,
+                    &successful_match.suggested_name,
                 );
                 Err(output)
             }

--- a/src/commands/moves_command.rs
+++ b/src/commands/moves_command.rs
@@ -97,8 +97,8 @@ impl MovesCommand<'_> {
             Ok(pokemon) => Ok(pokemon),
             Err(_) => {
                 let output = matcher::build_unknown_name(
-                    &successful_match.suggested_name,
                     &successful_match.keyword,
+                    &successful_match.suggested_name,
                 );
                 Err(output)
             }

--- a/src/commands/pokemon_command.rs
+++ b/src/commands/pokemon_command.rs
@@ -96,8 +96,8 @@ impl PokemonCommand<'_> {
             Ok(pokemon) => Ok(pokemon),
             Err(_) => {
                 let output = matcher::build_unknown_name(
-                    &successful_match.suggested_name,
                     &successful_match.keyword,
+                    &successful_match.suggested_name,
                 );
                 Err(output)
             }

--- a/src/commands/type_command.rs
+++ b/src/commands/type_command.rs
@@ -155,8 +155,8 @@ impl TypeCommand<'_> {
             Ok(type_) => Ok(type_),
             Err(_) => {
                 let output = matcher::build_unknown_name(
-                    &successful_match.suggested_name,
                     &successful_match.keyword,
+                    &successful_match.suggested_name,
                 );
                 Err(output)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["move", incorrect_name]);
-        let expected = matcher::build_unknown_name(incorrect_name, "move");
+        let expected = matcher::build_unknown_name("move", incorrect_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -150,7 +150,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["move", incorrect_name]);
-        let expected = build_suggestion("move", incorrect_name, correct_name);
+        let expected = matcher::build_suggestion("move", incorrect_name, correct_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -164,7 +164,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["pokemon", incorrect_name]);
-        let expected = matcher::build_unknown_name(incorrect_name, "pokemon");
+        let expected = matcher::build_unknown_name("pokemon", incorrect_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -179,7 +179,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["pokemon", incorrect_name]);
-        let expected = build_suggestion("pokemon", incorrect_name, correct_name);
+        let expected = matcher::build_suggestion("pokemon", incorrect_name, correct_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -193,7 +193,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["type", incorrect_name]);
-        let expected = matcher::build_unknown_name(incorrect_name, "type");
+        let expected = matcher::build_unknown_name("type", incorrect_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -208,7 +208,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["type", incorrect_name]);
-        let expected = build_suggestion("type", incorrect_name, correct_name);
+        let expected = matcher::build_suggestion("type", incorrect_name, correct_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -230,7 +230,7 @@ mod tests {
             .returning(|_args| Ok(Type::default()));
 
         let cli = parse_args(vec!["type", correct_name, "-s", incorrect_name]);
-        let expected = matcher::build_unknown_name(incorrect_name, "type");
+        let expected = matcher::build_unknown_name("type", incorrect_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -252,7 +252,7 @@ mod tests {
             .returning(|_args| Ok(Type::default()));
 
         let cli = parse_args(vec!["type", correct_name, "-s", incorrect_name]);
-        let expected = build_suggestion("type", incorrect_name, "psychic");
+        let expected = matcher::build_suggestion("type", incorrect_name, "psychic");
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -265,9 +265,5 @@ mod tests {
         full_args.extend(args);
 
         Cli::parse_from(full_args)
-    }
-
-    fn build_suggestion(keyword: &str, name: &str, correct_name: &str) -> String {
-        format!("Unknown {keyword} \"{name}\"\nDid you mean \"{correct_name}\"?")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["move", incorrect_name]);
-        let expected = matcher::build_suggestion("move", incorrect_name, correct_name);
+        let expected = matcher::build_suggested_name("move", incorrect_name, correct_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -179,7 +179,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["pokemon", incorrect_name]);
-        let expected = matcher::build_suggestion("pokemon", incorrect_name, correct_name);
+        let expected = matcher::build_suggested_name("pokemon", incorrect_name, correct_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -208,7 +208,7 @@ mod tests {
 
         let mock_client = MockClientImplementation::new();
         let cli = parse_args(vec!["type", incorrect_name]);
-        let expected = matcher::build_suggestion("type", incorrect_name, correct_name);
+        let expected = matcher::build_suggested_name("type", incorrect_name, correct_name);
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);
@@ -252,7 +252,7 @@ mod tests {
             .returning(|_args| Ok(Type::default()));
 
         let cli = parse_args(vec!["type", correct_name, "-s", incorrect_name]);
-        let expected = matcher::build_suggestion("type", incorrect_name, "psychic");
+        let expected = matcher::build_suggested_name("type", incorrect_name, "psychic");
         let actual = run(&mock_client, cli).await.to_string();
 
         assert_eq!(expected, actual);

--- a/src/name_matcher/matcher.rs
+++ b/src/name_matcher/matcher.rs
@@ -108,21 +108,21 @@ pub fn match_name(name: &str, matcher_type: MatcherType) -> Result<SuccessfulMat
                 Ok(successful_match)
             }
             Certainty::Uncertain => Err(NoMatch::new(build_suggestion(
-                name,
                 &keyword,
+                name,
                 &suggestion.name,
             ))),
         },
 
-        None => Err(NoMatch::new(build_unknown_name(name, &keyword))),
+        None => Err(NoMatch::new(build_unknown_name(&keyword, name))),
     }
 }
 
-fn build_suggestion(name: &str, keyword: &str, suggestion: &str) -> String {
+pub fn build_suggestion(keyword: &str, name: &str, suggestion: &str) -> String {
     format!("Unknown {keyword} \"{name}\"\nDid you mean \"{suggestion}\"?")
 }
 
-pub fn build_unknown_name(name: &str, keyword: &str) -> String {
+pub fn build_unknown_name(keyword: &str, name: &str) -> String {
     format!("{} \"{}\" doesn't exist", capitalise(keyword), name)
 }
 

--- a/src/name_matcher/matcher.rs
+++ b/src/name_matcher/matcher.rs
@@ -107,7 +107,7 @@ pub fn match_name(name: &str, matcher_type: MatcherType) -> Result<SuccessfulMat
 
                 Ok(successful_match)
             }
-            Certainty::Uncertain => Err(NoMatch::new(build_suggestion(
+            Certainty::Uncertain => Err(NoMatch::new(build_suggested_name(
                 &keyword,
                 name,
                 &suggestion.name,
@@ -118,7 +118,7 @@ pub fn match_name(name: &str, matcher_type: MatcherType) -> Result<SuccessfulMat
     }
 }
 
-pub fn build_suggestion(keyword: &str, name: &str, suggestion: &str) -> String {
+pub fn build_suggested_name(keyword: &str, name: &str, suggestion: &str) -> String {
     format!("Unknown {keyword} \"{name}\"\nDid you mean \"{suggestion}\"?")
 }
 

--- a/src/name_matcher/matcher.rs
+++ b/src/name_matcher/matcher.rs
@@ -6,7 +6,7 @@ use crate::{
 use ngrammatic::{Corpus, CorpusBuilder, Pad};
 use once_cell::sync::Lazy;
 
-static MIN_SIMILARITY: f32 = 0.5;
+static MIN_CERTAIN_SIMILARITY: f32 = 0.8;
 
 pub enum MatcherType {
     Pokemon,
@@ -24,7 +24,7 @@ impl SuccessfulMatch {
     pub fn new(original_name: String, keyword: String, suggestion: Suggestion) -> Self {
         Self {
             original_name,
-            suggested_name: suggestion.0,
+            suggested_name: suggestion.name,
             keyword,
         }
     }
@@ -38,11 +38,23 @@ impl NoMatch {
     }
 }
 
-pub struct Suggestion(String);
+enum Certainty {
+    Certain,
+    Uncertain,
+}
+
+pub struct Suggestion {
+    name: String,
+    certainty: Certainty,
+}
 
 impl Suggestion {
-    pub fn new(name: String) -> Self {
-        Self(name)
+    fn new(name: String, certainty: Certainty) -> Self {
+        Self { name, certainty }
+    }
+
+    fn certain(name: String) -> Self {
+        Self::new(name, Certainty::Certain)
     }
 }
 
@@ -60,11 +72,13 @@ impl NameMatcher {
         let search_results = corpus.search(name, 0.25);
         let search_result = search_results.first().map(|r| r.to_owned())?;
 
-        if search_result.similarity > MIN_SIMILARITY {
-            Some(Suggestion::new(search_result.text))
+        let certainty = if search_result.similarity > MIN_CERTAIN_SIMILARITY {
+            Certainty::Certain
         } else {
-            None
-        }
+            Certainty::Uncertain
+        };
+
+        Some(Suggestion::new(search_result.text, certainty))
     }
 
     fn build_corpus(&self) -> Corpus {
@@ -80,20 +94,32 @@ pub fn match_name(name: &str, matcher_type: MatcherType) -> Result<SuccessfulMat
     let (name_matcher, keyword) = matcher_and_keyword(matcher_type);
 
     if name_is_already_valid(&name_matcher.names, &name.to_owned()) {
-        let suggestion = Suggestion::new(name.to_owned());
+        let suggestion = Suggestion::certain(name.to_owned());
         let successful_match = SuccessfulMatch::new(name.to_owned(), keyword, suggestion);
 
         return Ok(successful_match);
     }
 
     match name_matcher.find_match(name) {
-        Some(suggestion) => {
-            let successful_match = SuccessfulMatch::new(name.to_owned(), keyword, suggestion);
-            Ok(successful_match)
-        }
+        Some(suggestion) => match suggestion.certainty {
+            Certainty::Certain => {
+                let successful_match = SuccessfulMatch::new(name.to_owned(), keyword, suggestion);
+
+                Ok(successful_match)
+            }
+            Certainty::Uncertain => Err(NoMatch::new(build_suggestion(
+                name,
+                &keyword,
+                &suggestion.name,
+            ))),
+        },
 
         None => Err(NoMatch::new(build_unknown_name(name, &keyword))),
     }
+}
+
+fn build_suggestion(name: &str, keyword: &str, suggestion: &str) -> String {
+    format!("Unknown {keyword} \"{name}\"\nDid you mean \"{suggestion}\"?")
 }
 
 pub fn build_unknown_name(name: &str, keyword: &str) -> String {


### PR DESCRIPTION
In https://github.com/DanielGilchrist/poke_search/pull/37 suggestions were completely removed (and tests were lazily removed as well 👀). Instead of telling the user that a pokemon doesn't exist if they really mess up the typing it would still be helpful to make a suggestion (and to have tests)

This also bumps auto correcting certainty from 50% to 80%. The idea is that auto correct would happen for simple mistypes and would fall back to a suggestion otherwise