### PR TITLE
Autocorrect "categories" for moves command

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,6 @@ Have a look [here](https://rust-script.org/#installation) for instructions on in
 rust-script scripts/replace_pokemon_names.rs
 ```
 
-This is used to populate names for `name_matcher` to suggest pokemon names, moves names and type names when entered incorrectly with a command.
+This is used to populate names for `name_matcher` to suggest pokemon names, moves names, move damage classes (categories) and type names when entered incorrectly with a command.
 
 The script fetches names from the Poke API repo and populated `<type>_names.rs` with a `Lazy<Vec<String>>` so the names are only initialised when used.

--- a/scripts/replace_pokemon_names.rs
+++ b/scripts/replace_pokemon_names.rs
@@ -24,6 +24,10 @@ const SOURCES: &'static [(&'static str, &'static str)] = &[
   (
     "https://raw.githubusercontent.com/PokeAPI/pokeapi/master/data/v2/csv/types.csv",
     "type_names"
+  ),
+  (
+    "https://raw.githubusercontent.com/PokeAPI/pokeapi/master/data/v2/csv/move_damage_classes.csv",
+    "move_damage_class_names"
   )
 ];
 
@@ -44,6 +48,7 @@ fn fetch_and_replace(url: &str, file_name: &str) -> Result<(), Box<dyn std::erro
   let mut reader = csv::Reader::from_reader(csv.as_bytes());
   let mut names = reader.records().map(|record| record.unwrap()[1].to_string()).collect::<Vec<_>>();
 
+  // This is important as we rely on binary search if we need to find a name in the vector in name_matcher::matcher.
   names.sort();
 
   let joined_names = names

--- a/src/commands/moves_command.rs
+++ b/src/commands/moves_command.rs
@@ -165,18 +165,30 @@ impl MovesCommand<'_> {
         };
 
         processed_moves = match &self.categories {
-            Some(categories) => processed_moves
+            Some(categories) => {
+              let corrected_categories = categories
+                .iter()
+                .map(|category| {
+                  match matcher::match_name(category, matcher::MatcherType::MoveDamageCategory) {
+                    Ok(successful_match) => successful_match.suggested_name,
+                    Err(_) => category.to_owned(),
+                  }
+                })
+                .collect::<Vec<_>>();
+
+              processed_moves
                 .into_iter()
                 .filter_map(|format_move| {
                     let move_ = &format_move.move_;
 
-                    if categories.contains(&move_.damage_class.name) {
+                    if corrected_categories.contains(&move_.damage_class.name) {
                         Some(format_move)
                     } else {
                         None
                     }
                 })
-                .collect::<Vec<_>>(),
+                .collect::<Vec<_>>()
+            },
             None => processed_moves,
         };
 

--- a/src/commands/moves_command.rs
+++ b/src/commands/moves_command.rs
@@ -166,29 +166,32 @@ impl MovesCommand<'_> {
 
         processed_moves = match &self.categories {
             Some(categories) => {
-              let corrected_categories = categories
-                .iter()
-                .map(|category| {
-                  match matcher::match_name(category, matcher::MatcherType::MoveDamageCategory) {
-                    Ok(successful_match) => successful_match.suggested_name,
-                    Err(_) => category.to_owned(),
-                  }
-                })
-                .collect::<Vec<_>>();
+                let corrected_categories = categories
+                    .iter()
+                    .map(|category| {
+                        match matcher::match_name(
+                            category,
+                            matcher::MatcherType::MoveDamageCategory,
+                        ) {
+                            Ok(successful_match) => successful_match.suggested_name,
+                            Err(_) => category.to_owned(),
+                        }
+                    })
+                    .collect::<Vec<_>>();
 
-              processed_moves
-                .into_iter()
-                .filter_map(|format_move| {
-                    let move_ = &format_move.move_;
+                processed_moves
+                    .into_iter()
+                    .filter_map(|format_move| {
+                        let move_ = &format_move.move_;
 
-                    if corrected_categories.contains(&move_.damage_class.name) {
-                        Some(format_move)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>()
-            },
+                        if corrected_categories.contains(&move_.damage_class.name) {
+                            Some(format_move)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            }
             None => processed_moves,
         };
 

--- a/src/name_matcher/matcher.rs
+++ b/src/name_matcher/matcher.rs
@@ -1,6 +1,6 @@
 use crate::{
     formatter::capitalise,
-    name_matcher::{move_names::MOVE_NAMES, pokemon_names::POKEMON_NAMES, type_names::TYPE_NAMES},
+    name_matcher::{move_names::MOVE_NAMES, move_damage_class_names::MOVE_DAMAGE_CLASS_NAMES, pokemon_names::POKEMON_NAMES, type_names::TYPE_NAMES},
 };
 
 use ngrammatic::{Corpus, CorpusBuilder, Pad};
@@ -11,6 +11,7 @@ static MIN_CERTAIN_SIMILARITY: f32 = 0.78;
 pub enum MatcherType {
     Pokemon,
     Move,
+    MoveDamageCategory,
     Type,
 }
 
@@ -135,6 +136,7 @@ fn matcher_and_keyword(matcher_type: MatcherType) -> (NameMatcher, String) {
         MatcherType::Move => (&MOVE_NAMES, "move"),
         MatcherType::Pokemon => (&POKEMON_NAMES, "pokemon"),
         MatcherType::Type => (&TYPE_NAMES, "type"),
+        MatcherType::MoveDamageCategory => (&MOVE_DAMAGE_CLASS_NAMES, "move damage category")
     };
 
     (

--- a/src/name_matcher/matcher.rs
+++ b/src/name_matcher/matcher.rs
@@ -1,6 +1,9 @@
 use crate::{
     formatter::capitalise,
-    name_matcher::{move_names::MOVE_NAMES, move_damage_class_names::MOVE_DAMAGE_CLASS_NAMES, pokemon_names::POKEMON_NAMES, type_names::TYPE_NAMES},
+    name_matcher::{
+        move_damage_class_names::MOVE_DAMAGE_CLASS_NAMES, move_names::MOVE_NAMES,
+        pokemon_names::POKEMON_NAMES, type_names::TYPE_NAMES,
+    },
 };
 
 use ngrammatic::{Corpus, CorpusBuilder, Pad};
@@ -136,7 +139,7 @@ fn matcher_and_keyword(matcher_type: MatcherType) -> (NameMatcher, String) {
         MatcherType::Move => (&MOVE_NAMES, "move"),
         MatcherType::Pokemon => (&POKEMON_NAMES, "pokemon"),
         MatcherType::Type => (&TYPE_NAMES, "type"),
-        MatcherType::MoveDamageCategory => (&MOVE_DAMAGE_CLASS_NAMES, "move damage category")
+        MatcherType::MoveDamageCategory => (&MOVE_DAMAGE_CLASS_NAMES, "move damage category"),
     };
 
     (

--- a/src/name_matcher/mod.rs
+++ b/src/name_matcher/mod.rs
@@ -1,4 +1,5 @@
 pub mod matcher;
+pub mod move_damage_class_names;
 pub mod move_names;
 pub mod pokemon_names;
 pub mod type_names;

--- a/src/name_matcher/move_damage_class_names.rs
+++ b/src/name_matcher/move_damage_class_names.rs
@@ -1,0 +1,9 @@
+use once_cell::sync::Lazy;
+
+pub static MOVE_DAMAGE_CLASS_NAMES: Lazy<Vec<String>> = Lazy::new(|| {
+    vec![
+        String::from("physical"),
+        String::from("special"),
+        String::from("status"),
+    ]
+});


### PR DESCRIPTION
<img width="803" alt="image" src="https://github.com/DanielGilchrist/poke_search/assets/13454550/9367c6e7-ff9d-4fb5-8631-037eb3754e90">


There's some inconsistency with naming (move damage _category_ vs move damage _class_) but I'm too lazy to fix that up for now