### PR TITLE
Wrap text for long outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "mockall",
  "ngrammatic",
  "rustemon",
+ "textwrap",
  "tokio",
 ]
 
@@ -1393,6 +1394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1503,17 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -1704,6 +1722,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ itertools = "0" # https://github.com/rust-itertools/itertools
 mockall = "0" # https://github.com/asomers/mockall
 ngrammatic = "0" # https://github.com/compenguy/ngrammatic
 rustemon = "3" # https://github.com/mlemesle/rustemon
+textwrap = "0" # https://github.com/mgeisler/textwrap
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] } # https://github.com/tokio-rs/tokio

--- a/src/formatter/move_.rs
+++ b/src/formatter/move_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    formatter::utils::{formatln, parse_maybe_i64, split_and_capitalise, white},
+    formatter::utils::{clean_and_wrap_text, formatln, parse_maybe_i64, split_and_capitalise, white},
     type_colours::{self},
 };
 
@@ -106,7 +106,8 @@ impl FormatMove {
                     .replace("$effect_chance%", &effect_chance)
             };
 
-            output.push_str(&formatln(&white("Effect"), &description));
+            let wrapped_description = clean_and_wrap_text(&description, 4, 80);
+            output.push_str(&formatln(&white("Effect"), &wrapped_description));
         });
     }
 

--- a/src/formatter/move_.rs
+++ b/src/formatter/move_.rs
@@ -1,5 +1,7 @@
 use crate::{
-    formatter::utils::{clean_and_wrap_text, formatln, parse_maybe_i64, split_and_capitalise, white},
+    formatter::utils::{
+        clean_and_wrap_text, formatln, parse_maybe_i64, split_and_capitalise, white,
+    },
     type_colours::{self},
 };
 

--- a/src/formatter/utils.rs
+++ b/src/formatter/utils.rs
@@ -1,8 +1,6 @@
 use colored::{ColoredString, Colorize};
 use rustemon::model::resource::VerboseEffect;
 
-use textwrap;
-
 pub(crate) fn capitalise(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {

--- a/src/formatter/utils.rs
+++ b/src/formatter/utils.rs
@@ -1,6 +1,8 @@
 use colored::{ColoredString, Colorize};
 use rustemon::model::resource::VerboseEffect;
 
+use textwrap;
+
 pub(crate) fn capitalise(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
@@ -18,15 +20,16 @@ pub(crate) fn formatln(title: &str, value: &str) -> String {
 }
 
 pub(crate) fn extract_effect(effect_entries: &[VerboseEffect]) -> Option<String> {
-    let effect = effect_entries.iter().find_map(|verbose_effect| {
+    let formatted_effect = effect_entries.iter().find_map(|verbose_effect| {
         if verbose_effect.language.name == "en" {
-            Some(&verbose_effect.effect)
+            let effect = &verbose_effect.effect;
+            Some(clean_and_wrap_text(effect, 4, 80))
         } else {
             None
         }
     })?;
 
-    Some(effect.replace('\n', " "))
+    Some(formatted_effect)
 }
 
 pub(crate) fn parse_maybe_i64(value: Option<i64>) -> String {
@@ -34,6 +37,21 @@ pub(crate) fn parse_maybe_i64(value: Option<i64>) -> String {
         Some(value) => value.to_string(),
         None => String::from("-"),
     }
+}
+
+pub(crate) fn clean_and_wrap_text(text: &str, indent: usize, width: usize) -> String {
+    let cleaned_text = text
+        .replace("\n:", ":")
+        .replace(":  ", ": ")
+        .replace("  ", " ")
+        .replace("\n  ", "\n")
+        .trim()
+        .to_owned();
+
+    let spaces = &" ".repeat(indent);
+    let options = textwrap::Options::new(width).subsequent_indent(spaces);
+
+    textwrap::fill(&cleaned_text, options)
 }
 
 // Colours


### PR DESCRIPTION
Before
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/2ef4c93e-0e10-456b-b83f-c0d93ed852ca">

After
<img width="794" alt="image" src="https://github.com/user-attachments/assets/e5a45a09-be6f-4a5c-a97d-fd1d13939a43">
